### PR TITLE
Fixed events.xml schema

### DIFF
--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -20,7 +20,7 @@
  * @license     https://www.mageplaza.com/LICENSE.txt
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="controller_action_predispatch_adminhtml_auth_forgotpassword">
         <observer name="msp_recaptcha" instance="Mageplaza\GoogleRecaptcha\Observer\Adminhtml\Forgot"/>
     </event>


### PR DESCRIPTION
Events schema should be used for events.xml.

Current implementation is using system_file which causes the following error:

```
13) Magento\Test\Integrity\Xml\SchemaTest::testXmlFiles
Passed: 1953, Failed: 4, Incomplete: 0, Skipped: 0.
Data set: /vendor/mageplaza/module-google-recaptcha/etc/adminhtml/events.xml
Error validating /home/travis/build/SemExpert/[...]/magento2/vendor/mageplaza/module-google-recaptcha/etc/adminhtml/events.xml against urn:magento:module:Magento_Config:etc/system_file.xsd
Array
(
    [0] => Element 'event': This element is not expected. Expected is ( system ).
Line: 24
)
```